### PR TITLE
Dev

### DIFF
--- a/src/Infrastructure/Database/Cast/BearAsJsonCast.php
+++ b/src/Infrastructure/Database/Cast/BearAsJsonCast.php
@@ -6,8 +6,16 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use stdClass;
 
 class BearAsJsonCast implements CastsAttributes {
-    public function get($model, string $key, mixed $value, array$attributes): stdClass|null|array {
-        return $value === null ? new stdClass() : json_decode($value, false, 512, JSON_THROW_ON_ERROR);
+    public function get($model, string $key, mixed $value, array$attributes): stdClass|null|\ArrayObject {
+        if ($value === null) {
+            return new stdClass();
+        }
+        $decodedJson = json_decode($value, false, 512, JSON_THROW_ON_ERROR);
+        if (is_array($decodedJson)) {
+            return new \ArrayObject($decodedJson);
+        }
+
+        return $decodedJson;
     }
 
     public function set($model, string $key, mixed $value, array $attributes): string {

--- a/src/Infrastructure/Database/Cast/BearAsJsonCast.php
+++ b/src/Infrastructure/Database/Cast/BearAsJsonCast.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use stdClass;
 
 class BearAsJsonCast implements CastsAttributes {
-    public function get($model, string $key, mixed $value, array$attributes): stdClass|null {
+    public function get($model, string $key, mixed $value, array$attributes): stdClass|null|array {
         return $value === null ? new stdClass() : json_decode($value, false, 512, JSON_THROW_ON_ERROR);
     }
 


### PR DESCRIPTION
`json_decode` can return array, not just stdClass or null. array was missing as return type.
I've changed it to return php native ArrayObject instead. Gives extra functionality and plays nicely with laravel